### PR TITLE
0 70 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ method.
 1. Add the following to your Gemfile
 
 <pre>
-    gem 'spree_skrill', :git => 'git://github.com/spree/spree_skrill.git'
+    gem 'spree_skrill', :git => 'git://github.com/spree/spree_skrill.git', :branch => '0-70-stable'
 </pre>
 
 2. Run `bundle install`
@@ -17,7 +17,7 @@ method.
 
 ## Configuring
 
-1. Add a new Payment Method, using: `BillingIntegration::Skrill::QuickCheckout` as the `Prodivder`
+1. Add a new Payment Method, using: `BillingIntegration::Skrill::QuickCheckout` as the `Provider`
 
 2. Click `Create`, and enter your Store's Skrill / MoneyBookers Merchant
    ID (also called Customer ID) in the field provide.
@@ -30,7 +30,7 @@ Testing
 
 Be sure to add the rspec-rails gem to your Gemfile and then create a dummy test app for the specs to run against.
 
-    $ bundle exec rake test app
+    $ bundle exec rake test_app
     $ bundle exec rspec spec
 
 Copyright (c) 2011 [name of extension creator], released under the New BSD License

--- a/lib/spree_skrill/engine.rb
+++ b/lib/spree_skrill/engine.rb
@@ -40,7 +40,7 @@ module SpreeSkrill
 
     initializer "spree_skrill.register.payment_methods" do |app|
       app.config.spree.payment_methods += [
-        Spree::BillingIntegration::Skrill::QuickCheckout
+        BillingIntegration::Skrill::QuickCheckout
       ]
     end
 


### PR DESCRIPTION
I was installing Skrill in my 0.70.4 store and got an error because engine.rb was anticipating the Spree::BillingIntegration namespacing from Spree 1.0 in the 0-70-stable branch. The pull request just eliminates the namespacing in the 0-70 branch.

I also caught a couple small README errors.

BTW, I ran the tests and 4 of 6 failed, though they had nothing to do with these small changes. In case it's helpful, I put the output up in this Gist: https://gist.github.com/2001927
